### PR TITLE
Fix LargeSnapshotChunkTest

### DIFF
--- a/large-snapshot-chunk-test/src/main/java/com/hazelcast/jet/tests/largesnapshotchunk/VerificationProcessor.java
+++ b/large-snapshot-chunk-test/src/main/java/com/hazelcast/jet/tests/largesnapshotchunk/VerificationProcessor.java
@@ -52,7 +52,6 @@ public final class VerificationProcessor extends AbstractProcessor {
             throw new IllegalArgumentException("Expected " + windowSize + " items, but got "
                     + casted.getValue().size());
         }
-        getLogger().info("verified ok, item=" + item);
         Long oldTime = timePerKey.put(casted.getKey(), casted.getTimestamp());
         if (oldTime == null) {
             oldTime = 0L;

--- a/large-snapshot-chunk-test/src/main/java/com/hazelcast/jet/tests/largesnapshotchunk/VerificationProcessor.java
+++ b/large-snapshot-chunk-test/src/main/java/com/hazelcast/jet/tests/largesnapshotchunk/VerificationProcessor.java
@@ -48,16 +48,16 @@ public final class VerificationProcessor extends AbstractProcessor {
     protected boolean tryProcess(int ordinal, Object item) {
         @SuppressWarnings("unchecked")
         TimestampedEntry<String, List<int[]>> casted = (TimestampedEntry<String, List<int[]>>) item;
-        long expectedNumberOfItems = Math.min(casted.getTimestamp(), windowSize);
-        if (casted.getValue().size() != expectedNumberOfItems) {
-            throw new IllegalArgumentException("Expected " + expectedNumberOfItems + " items, but got "
+        if (casted.getValue().size() != windowSize) {
+            throw new IllegalArgumentException("Expected " + windowSize + " items, but got "
                     + casted.getValue().size());
         }
+        getLogger().info("verified ok, item=" + item);
         Long oldTime = timePerKey.put(casted.getKey(), casted.getTimestamp());
         if (oldTime == null) {
             oldTime = 0L;
         }
-        if (oldTime != casted.getTimestamp() - 1) {
+        if (oldTime != casted.getTimestamp() - windowSize) {
             throw new IllegalArgumentException("Received item for time=" + casted.getTimestamp() + ", but the last " +
                     "received item for this key was with time=" + oldTime);
         }


### PR DESCRIPTION
The previous version didn't actually produce large snapshot chunks (it
stored frames of 1kB). Also produce large data only to 1st partition.