### PR TITLE
Fixed catch in HdfsWordCountTest

### DIFF
--- a/hdfs-test/src/main/java/com/hazelcast/jet/tests/hdfs/HdfsWordCountTest.java
+++ b/hdfs-test/src/main/java/com/hazelcast/jet/tests/hdfs/HdfsWordCountTest.java
@@ -104,8 +104,8 @@ public class HdfsWordCountTest extends AbstractSoakTest {
                     try {
                         executeJob(threadIndex);
                         verify(threadIndex);
-                    } catch (Exception e) {
-                        exception = e;
+                    } catch (Throwable e) {
+                        exception = new Exception(e);
                     }
                 }
             });


### PR DESCRIPTION
`verify()` method uses assertions to check results but `AssertionError` is `Throwable` not `Exception`. It means that `exception` is not set even if there is any assertion error in test. It can cause that test will looks like passed even if there was any failure.