### PR TITLE
Add s3 soak test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
     <description>Soak Tests for Hazelcast Jet</description>
     <modules>
         <module>async-transform-test</module>
+        <module>cooperative-map-cache-source-test</module>
         <module>early-results-test</module>
         <module>event-journal-test</module>
         <module>hdfs-test</module>
@@ -18,12 +19,12 @@
         <module>jms-test</module>
         <module>job-management-test</module>
         <module>kafka-session-window-test</module>
+        <module>large-snapshot-chunk-test</module>
         <module>remote-controller-client</module>
         <module>rolling-aggregate-test</module>
         <module>snapshot-test</module>
         <module>soak-tests-common</module>
-        <module>large-snapshot-chunk-test</module>
-        <module>cooperative-map-cache-source-test</module>
+        <module>s3-test</module>
     </modules>
 
     <properties>

--- a/s3-test/pom.xml
+++ b/s3-test/pom.xml
@@ -31,7 +31,7 @@
 
     <properties>
         <main.basedir>${project.parent.basedir}</main.basedir>
-        <hadoop.version>2.7.4</hadoop.version>
+        <aws.sdk.version>2.8.3</aws.sdk.version>
     </properties>
 
     <dependencyManagement>
@@ -39,7 +39,7 @@
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>bom</artifactId>
-                <version>2.8.3</version>
+                <version>${aws.sdk.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/s3-test/pom.xml
+++ b/s3-test/pom.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>s3-test</artifactId>
+
+    <parent>
+        <groupId>com.hazelcast.jet.tests</groupId>
+        <artifactId>hazelcast-jet-ansible-tests</artifactId>
+        <version>3.2-SNAPSHOT</version>
+    </parent>
+
+
+    <properties>
+        <main.basedir>${project.parent.basedir}</main.basedir>
+        <hadoop.version>2.7.4</hadoop.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>bom</artifactId>
+                <version>2.8.3</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.hazelcast.jet</groupId>
+            <artifactId>hazelcast-jet-s3</artifactId>
+            <version>${jet.version}</version>
+        </dependency>
+
+        <!-- s3 -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.hazelcast.jet.tests</groupId>
+            <artifactId>soak-tests-common</artifactId>
+            <version>${jet.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>annotations</artifactId>
+            <version>3.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/s3-test/src/main/java/com/hazelcast/jet/test/s3/S3WordCountTest.java
+++ b/s3-test/src/main/java/com/hazelcast/jet/test/s3/S3WordCountTest.java
@@ -55,7 +55,6 @@ public class S3WordCountTest extends AbstractSoakTest {
     private int totalWordCount;
 
     public static void main(String[] args) throws Exception {
-        System.setProperty("runLocal", "true");
         new S3WordCountTest().run(args);
     }
 

--- a/s3-test/src/main/java/com/hazelcast/jet/test/s3/S3WordCountTest.java
+++ b/s3-test/src/main/java/com/hazelcast/jet/test/s3/S3WordCountTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.test.s3;
+
+import com.hazelcast.jet.function.SupplierEx;
+import com.hazelcast.jet.impl.util.ExceptionUtil;
+import com.hazelcast.jet.pipeline.Pipeline;
+import com.hazelcast.jet.s3.S3Sinks;
+import com.hazelcast.jet.s3.S3Sources;
+import com.hazelcast.jet.tests.common.AbstractSoakTest;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.NoSuchBucketException;
+import software.amazon.awssdk.services.s3.model.S3Object;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Iterator;
+import java.util.StringTokenizer;
+
+import static com.hazelcast.jet.aggregate.AggregateOperations.counting;
+import static com.hazelcast.jet.function.Functions.wholeItem;
+import static com.hazelcast.jet.pipeline.Sources.batchFromProcessor;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Collections.singletonList;
+import static software.amazon.awssdk.regions.Region.US_EAST_1;
+
+public class S3WordCountTest extends AbstractSoakTest {
+
+    private static final String DEFAULT_BUCKET_NAME = "jet-soak-tests-source-bucket";
+    private static final String RESULTS_PREFIX = "results/";
+    private static final int DEFAULT_TOTAL = 400000;
+    private static final int DEFAULT_DISTINCT = 50000;
+
+
+    private S3Client s3Client;
+    private String bucketName;
+    private int distinct;
+    private int totalWordCount;
+
+    public static void main(String[] args) throws Exception {
+        System.setProperty("runLocal", "true");
+        new S3WordCountTest().run(args);
+    }
+
+    @Override
+    protected void init() {
+        bucketName = property("bucket_name", DEFAULT_BUCKET_NAME);
+        distinct = propertyInt("distinct_words", DEFAULT_DISTINCT);
+        totalWordCount = propertyInt("total_word_count", DEFAULT_TOTAL);
+
+        s3Client = clientSupplier().get();
+        deleteBucket();
+        createBucket();
+
+        Pipeline p = Pipeline.create();
+        p.drawFrom(batchFromProcessor("s3-word-generator",
+                WordGenerator.metaSupplier(distinct, totalWordCount)))
+         .drainTo(S3Sinks.s3(bucketName, clientSupplier()));
+
+        jet.newJob(p).join();
+    }
+
+    @Override
+    protected void test() {
+        long begin = System.currentTimeMillis();
+        while ((System.currentTimeMillis() - begin) < durationInMillis) {
+            jet.newJob(pipeline()).join();
+            verify();
+        }
+    }
+
+    private Pipeline pipeline() {
+        Pipeline pipeline = Pipeline.create();
+
+        pipeline.drawFrom(S3Sources.s3(singletonList(bucketName), null, clientSupplier()))
+                .flatMap((String line) -> {
+                    StringTokenizer s = new StringTokenizer(line);
+                    return () -> s.hasMoreTokens() ? s.nextToken() : null;
+                })
+                .groupingKey(wholeItem())
+                .aggregate(counting())
+                .drainTo(S3Sinks.s3(bucketName, RESULTS_PREFIX, UTF_8,
+                        clientSupplier(), e -> e.getKey() + " " + e.getValue()));
+
+        return pipeline;
+    }
+
+    private void verify() {
+        Iterator<S3Object> iterator = s3Client.listObjectsV2Paginator(
+                b -> b.bucket(bucketName).prefix(RESULTS_PREFIX)).contents().iterator();
+
+        int wordNumber = 0;
+        int totalNumber = 0;
+        while (iterator.hasNext()) {
+            S3Object s3Object = iterator.next();
+            try (ResponseInputStream<GetObjectResponse> response =
+                         s3Client.getObject(b -> b.bucket(bucketName).key(s3Object.key()))) {
+                BufferedReader reader = new BufferedReader(new InputStreamReader(response));
+                String line = reader.readLine();
+                while (line != null) {
+                    wordNumber++;
+                    totalNumber += Integer.parseInt(line.split(" ")[1]);
+                    line = reader.readLine();
+                }
+            } catch (IOException e) {
+                throw ExceptionUtil.rethrow(e);
+            }
+            s3Client.deleteObject(b -> b.bucket(bucketName).key(s3Object.key()));
+        }
+        assertEquals(distinct, wordNumber);
+        assertEquals(totalWordCount, totalNumber);
+    }
+
+
+    @Override
+    protected void teardown() {
+        deleteBucket();
+    }
+
+    private SupplierEx<S3Client> clientSupplier() {
+        return () -> S3Client.builder().region(US_EAST_1).build();
+    }
+
+    private void createBucket() {
+        s3Client.createBucket(b -> b.bucket(bucketName));
+    }
+
+    private void deleteBucket() {
+        try {
+            s3Client.deleteBucket(b -> b.bucket(bucketName));
+        } catch (NoSuchBucketException ignored) {
+        }
+    }
+}

--- a/s3-test/src/main/java/com/hazelcast/jet/test/s3/S3WordCountTest.java
+++ b/s3-test/src/main/java/com/hazelcast/jet/test/s3/S3WordCountTest.java
@@ -61,9 +61,9 @@ public class S3WordCountTest extends AbstractSoakTest {
 
     @Override
     protected void init() {
-        bucketName = property("bucket_name", DEFAULT_BUCKET_NAME);
-        distinct = propertyInt("distinct_words", DEFAULT_DISTINCT);
-        totalWordCount = propertyInt("total_word_count", DEFAULT_TOTAL);
+        bucketName = property("bucketName", DEFAULT_BUCKET_NAME);
+        distinct = propertyInt("distinctWords", DEFAULT_DISTINCT);
+        totalWordCount = propertyInt("totalWordCount", DEFAULT_TOTAL);
 
         s3Client = clientSupplier().get();
         deleteBucket();

--- a/s3-test/src/main/java/com/hazelcast/jet/test/s3/WordGenerator.java
+++ b/s3-test/src/main/java/com/hazelcast/jet/test/s3/WordGenerator.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.test.s3;
+
+import com.hazelcast.jet.Traverser;
+import com.hazelcast.jet.core.AbstractProcessor;
+import com.hazelcast.jet.core.ProcessorMetaSupplier;
+import com.hazelcast.jet.core.ProcessorSupplier;
+
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static com.hazelcast.jet.core.processor.Processors.noopP;
+
+public final class WordGenerator extends AbstractProcessor {
+
+    private static final int WORDS_PER_LINE = 20;
+
+    private final Traverser traverser;
+    private final StringBuilder builder = new StringBuilder();
+
+    private int lineNumber;
+
+    private WordGenerator(int distinctWords, int perMemberWordCount) {
+        int lineCount = perMemberWordCount / WORDS_PER_LINE;
+        int[] wordNumber = new int[1];
+        traverser = () -> {
+            if (lineNumber == lineCount) {
+                return null;
+            }
+            for (int i = 0; i < WORDS_PER_LINE; i++) {
+                builder.append(wordNumber[0] % distinctWords).append(" ");
+                wordNumber[0]++;
+            }
+            try {
+                return builder.toString();
+            } finally {
+                lineNumber++;
+                builder.setLength(0);
+            }
+        };
+    }
+
+    @Override
+    public boolean complete() {
+        return emitFromTraverser(traverser);
+    }
+
+    static ProcessorMetaSupplier metaSupplier(int distinctWords, int totalWordCount) {
+        return addresses -> {
+            assert totalWordCount % (addresses.size() * WORDS_PER_LINE) == 0;
+            int perMemberWordCount = totalWordCount / addresses.size();
+            return address -> processorSupplier(distinctWords, perMemberWordCount);
+        };
+    }
+
+    private static ProcessorSupplier processorSupplier(int distinctWords, int perMemberWordCount) {
+        return count -> IntStream
+                .range(0, count)
+                .mapToObj(i -> i == 0 ? new WordGenerator(distinctWords, perMemberWordCount) : noopP().get())
+                .collect(Collectors.toList());
+    }
+
+}


### PR DESCRIPTION
added a word-count test which reads from an S3 bucket and writes the results to the same bucket in a folder. source files are generated at the beginning of the test

see https://github.com/hazelcast/hazelcast-jet-ansible/pull/14