### PR TITLE
Changes during 3.2 release

### DIFF
--- a/async-transform-test/pom.xml
+++ b/async-transform-test/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
         <groupId>com.hazelcast.jet.tests</groupId>
-        <version>3.2-SNAPSHOT</version>
+        <version>3.2</version>
     </parent>
 
     <properties>

--- a/cooperative-map-cache-source-test/pom.xml
+++ b/cooperative-map-cache-source-test/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.hazelcast.jet.tests</groupId>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
-        <version>3.2-SNAPSHOT</version>
+        <version>3.2</version>
     </parent>
 
     <properties>

--- a/early-results-test/pom.xml
+++ b/early-results-test/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
         <groupId>com.hazelcast.jet.tests</groupId>
-        <version>3.2-SNAPSHOT</version>
+        <version>3.2</version>
     </parent>
 
     <properties>

--- a/event-journal-test/pom.xml
+++ b/event-journal-test/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
         <groupId>com.hazelcast.jet.tests</groupId>
-        <version>3.2-SNAPSHOT</version>
+        <version>3.2</version>
     </parent>
 
     <properties>

--- a/hdfs-test/pom.xml
+++ b/hdfs-test/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.hazelcast.jet.tests</groupId>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
-        <version>3.2-SNAPSHOT</version>
+        <version>3.2</version>
     </parent>
 
 

--- a/jdbc-test/pom.xml
+++ b/jdbc-test/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
         <groupId>com.hazelcast.jet.tests</groupId>
-        <version>3.2-SNAPSHOT</version>
+        <version>3.2</version>
     </parent>
     <properties>
         <main.basedir>${project.parent.basedir}</main.basedir>

--- a/jms-test/pom.xml
+++ b/jms-test/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
         <groupId>com.hazelcast.jet.tests</groupId>
-        <version>3.2-SNAPSHOT</version>
+        <version>3.2</version>
     </parent>
 
     <properties>

--- a/job-management-test/pom.xml
+++ b/job-management-test/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
         <groupId>com.hazelcast.jet.tests</groupId>
-        <version>3.2-SNAPSHOT</version>
+        <version>3.2</version>
     </parent>
 
     <properties>

--- a/job-management-test/src/main/java/com/hazelcast/jet/tests/management/VerificationProcessor.java
+++ b/job-management-test/src/main/java/com/hazelcast/jet/tests/management/VerificationProcessor.java
@@ -34,7 +34,7 @@ public final class VerificationProcessor extends AbstractProcessor {
 
     private boolean processed;
     private long counter;
-    private PriorityQueue<Long> queue = new PriorityQueue<>();
+    private final PriorityQueue<Long> queue = new PriorityQueue<>();
     private ILogger logger;
 
     private VerificationProcessor(boolean odds) {
@@ -78,7 +78,7 @@ public final class VerificationProcessor extends AbstractProcessor {
     @Override
     protected void restoreFromSnapshot(Object key, Object value) {
         counter = (Long) ((BroadcastKey) key).key();
-        queue = (PriorityQueue<Long>) value;
+        queue.addAll((PriorityQueue<Long>) value);
 
         logger.info(String.format("restoreFromSnapshot odd: %b, counter: %d, size: %d, peek: %d",
                 odds, counter, queue.size(), queue.peek()));

--- a/kafka-session-window-test/pom.xml
+++ b/kafka-session-window-test/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.hazelcast.jet.tests</groupId>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
-        <version>3.2-SNAPSHOT</version>
+        <version>3.2</version>
     </parent>
 
     <properties>

--- a/large-snapshot-chunk-test/pom.xml
+++ b/large-snapshot-chunk-test/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
         <groupId>com.hazelcast.jet.tests</groupId>
-        <version>3.2-SNAPSHOT</version>
+        <version>3.2</version>
     </parent>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.hazelcast.jet.tests</groupId>
     <artifactId>hazelcast-jet-ansible-tests</artifactId>
     <packaging>pom</packaging>
-    <version>3.2-SNAPSHOT</version>
+    <version>3.2</version>
     <description>Soak Tests for Hazelcast Jet</description>
     <modules>
         <module>async-transform-test</module>
@@ -30,7 +30,7 @@
 
     <properties>
         <jdk.version>1.8</jdk.version>
-        <jet.version>3.2-SNAPSHOT</jet.version>
+        <jet.version>3.2</jet.version>
         <main.basedir>${project.basedir}</main.basedir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 

--- a/remote-controller-client/pom.xml
+++ b/remote-controller-client/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
         <groupId>com.hazelcast.jet.tests</groupId>
-        <version>3.2-SNAPSHOT</version>
+        <version>3.2</version>
     </parent>
 
     <properties>

--- a/rolling-aggregate-test/pom.xml
+++ b/rolling-aggregate-test/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
         <groupId>com.hazelcast.jet.tests</groupId>
-        <version>3.2-SNAPSHOT</version>
+        <version>3.2</version>
     </parent>
 
     <properties>

--- a/s3-test/pom.xml
+++ b/s3-test/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.hazelcast.jet.tests</groupId>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
-        <version>3.2-SNAPSHOT</version>
+        <version>3.2</version>
     </parent>
 
 
@@ -57,6 +57,10 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>s3</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>apache-client</artifactId>
         </dependency>
 
         <dependency>

--- a/snapshot-test/pom.xml
+++ b/snapshot-test/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
         <groupId>com.hazelcast.jet.tests</groupId>
-        <version>3.2-SNAPSHOT</version>
+        <version>3.2</version>
     </parent>
 
     <properties>

--- a/snapshot-test/src/main/java/com/hazelcast/jet/tests/snapshot/SnapshotTest.java
+++ b/snapshot-test/src/main/java/com/hazelcast/jet/tests/snapshot/SnapshotTest.java
@@ -24,6 +24,7 @@ import com.hazelcast.jet.kafka.KafkaSources;
 import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.tests.common.AbstractSoakTest;
 import com.hazelcast.jet.tests.common.QueueVerifier;
+import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.LoggingService;
 import com.hazelcast.util.UuidUtil;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -84,8 +85,9 @@ public class SnapshotTest extends AbstractSoakTest {
         jobCount = propertyInt("jobCount", 2);
         countPerTicker = propertyInt("countPerTicker", DEFAULT_COUNTER_PER_TICKER);
 
+        ILogger producerLogger = getLogger(SnapshotTradeProducer.class);
         producerFuture = producerExecutorService.submit(() -> {
-            try (SnapshotTradeProducer tradeProducer = new SnapshotTradeProducer(brokerUri)) {
+            try (SnapshotTradeProducer tradeProducer = new SnapshotTradeProducer(brokerUri, producerLogger)) {
                 tradeProducer.produce(TOPIC, countPerTicker);
             } catch (Exception e) {
                 e.printStackTrace();

--- a/soak-tests-common/pom.xml
+++ b/soak-tests-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
         <groupId>com.hazelcast.jet.tests</groupId>
-        <version>3.2-SNAPSHOT</version>
+        <version>3.2</version>
     </parent>
 
     <properties>

--- a/soak-tests-common/src/main/java/com/hazelcast/jet/tests/common/Util.java
+++ b/soak-tests-common/src/main/java/com/hazelcast/jet/tests/common/Util.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.jet.tests.common;
 
+import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.Job;
 import com.hazelcast.jet.core.JobStatus;
 
@@ -66,10 +67,12 @@ public final class Util {
                 expectedStatus, job.getStatus()));
     }
 
-    public static void cancelJobAndJoin(Job job) {
-        job.cancel();
+    public static void cancelJobAndJoin(JetInstance jet, Job job) {
+        // workaround, it should be fixed in Jet 3.2.1
+        Job jobForCancelling = jet.getJob(job.getName());
+        jobForCancelling.cancel();
         try {
-            job.join();
+            jobForCancelling.join();
         } catch (CancellationException ignored) {
         }
     }

--- a/stateful-map-test/pom.xml
+++ b/stateful-map-test/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
         <groupId>com.hazelcast.jet.tests</groupId>
-        <version>3.2-SNAPSHOT</version>
+        <version>3.2</version>
     </parent>
 
     <properties>

--- a/stateful-map-test/src/main/java/com/hazelcast/jet/tests/stateful/TransactionGenerator.java
+++ b/stateful-map-test/src/main/java/com/hazelcast/jet/tests/stateful/TransactionGenerator.java
@@ -74,13 +74,14 @@ public final class TransactionGenerator {
     private void generateTrades(SourceBuilder.SourceBuffer<TransactionEvent> buf) {
         if (start && replicatedMap.get(STOP_GENERATION_MESSAGE) != null) {
             //this is to advance wm and eventually evict expired transactions
-            buf.add(new TransactionEvent(null, Long.MAX_VALUE, System.currentTimeMillis()));
+            buf.add(new TransactionEvent(null, Long.MAX_VALUE, Long.MAX_VALUE - 1));
             parkNanos(nanosBetweenEvents);
             return;
         }
         Type type = start ? Type.START : Type.END;
         for (int i = 0; i < batchCount; i++) {
-            buf.add(new TransactionEvent(type, txId + i, System.currentTimeMillis()));
+            long id = txId + i;
+            buf.add(new TransactionEvent(type, id, id));
             parkNanos(nanosBetweenEvents);
         }
         start = !start;
@@ -89,7 +90,7 @@ public final class TransactionGenerator {
         //Eventually the transaction will be evicted and marked as timeout
         //a single tx is produced per batch and txId<0
         if (start) {
-            buf.add(new TransactionEvent(Type.START, -txId, System.currentTimeMillis()));
+            buf.add(new TransactionEvent(Type.START, -txId, txId));
             replicatedMap.put(CURRENT_TX_ID, txId);
         }
     }

--- a/stateful-map-test/src/main/java/com/hazelcast/jet/tests/stateful/VerificationEntryProcessor.java
+++ b/stateful-map-test/src/main/java/com/hazelcast/jet/tests/stateful/VerificationEntryProcessor.java
@@ -24,14 +24,9 @@ import java.util.Map;
 public class VerificationEntryProcessor extends AbstractEntryProcessor<Long, Long> {
     @Override
     public Integer process(Map.Entry<Long, Long> entry) {
-        if (entry.getValue() == StatefulMapTest.TIMED_OUT_CODE) {
-            throw new IllegalArgumentException(String.format("Transaction[%d} timeout", entry.getKey()));
-        }
-        if (entry.getValue() >= 0) {
-            entry.setValue(null);
-            return 1;
-        }
-        return 0;
+        Long value = entry.getValue();
+        entry.setValue(null);
+        return value == StatefulMapTest.TIMED_OUT_CODE ? 0 : 1;
     }
 
     static Predicate<Long, Long> predicate(long maxKey) {


### PR DESCRIPTION
fix npe while cluster is shutting down

Log Exception for stable cluster even if dynamic test failed for stateful mapping

configure sink maps with hot restart

fix map name

log exception when it happens

remove pending logic

Fixed checkstyle error

change to deterministic ts

change ttl to event time

Fixed checkstyles

temp added logging to Util

Update cancelJobAndJoin

Cleanup in Util.cancelJobAndJoin

Updated timeout for S3Client

set socket timeout for client

Count socket timeout number and assert that it happens once in an hour (#28)

* count socket timeout number and assert that it happens once in an hour

* handle undefined-error-code for client

use stable cluster as a sink for stateful-map-test

fix sink map names

Added workaround in cancelJobAndJoin

Added checking of SocketException in S3 test

Merge methods for checking Socket related Exceptions in S3 test

Use de-duplication for async-transform verifier, re-init s3 client after socket related exception (#33)

* use de-duplication for async-transform verifier, re-init s3 client after socket related exception

* add more logging for async-transaform-test

Fixed Verifier in AsyncTransformTest

add sleep between each s3 job for throttling

Improve Util.getJobStatusWithRetry

Producer blocks on futures after each batch of items and retry if a send fails (#38)

Fix storing shared queue that's concurrently broadcast

Added retry for listObjectsV2Paginator in S3 test

Early result test fix (#42)

* log warning if no early result emitted, check for re-ordering of results

* add logging for re-order of results