### PR TITLE
2pc jms test

### DIFF
--- a/jms-test/src/main/java/com/hazelcast/jet/tests/jms/JmsTest.java
+++ b/jms-test/src/main/java/com/hazelcast/jet/tests/jms/JmsTest.java
@@ -119,6 +119,9 @@ public class JmsTest extends AbstractSoakTest {
         JobConfig jobConfig1 = new JobConfig()
                 .setName("JMS Test source to middle queue")
                 .setProcessingGuarantee(ProcessingGuarantee.EXACTLY_ONCE);
+        if (clusterName.equals(STABLE_CLUSTER)) {
+            jobConfig1.addClass(JmsTest.class, JmsMessageProducer.class, JmsMessageConsumer.class);
+        }
         Job job1 = client.newJob(p1, jobConfig1);
         waitForJobStatus(job1, RUNNING);
         log(logger, "Job1 started", clusterName);
@@ -126,6 +129,9 @@ public class JmsTest extends AbstractSoakTest {
         JobConfig jobConfig2 = new JobConfig()
                 .setName("JMS Test middle to sink queue")
                 .setProcessingGuarantee(ProcessingGuarantee.EXACTLY_ONCE);
+        if (clusterName.equals(STABLE_CLUSTER)) {
+            jobConfig2.addClass(JmsTest.class, JmsMessageProducer.class, JmsMessageConsumer.class);
+        }
         Job job2 = client.newJob(p2, jobConfig2);
         waitForJobStatus(job2, RUNNING);
         log(logger, "Job2 started", clusterName);

--- a/snapshot-kafka-test/src/main/java/com/hazelcast/jet/tests/snapshot/kafka/SnapshotKafkaTest.java
+++ b/snapshot-kafka-test/src/main/java/com/hazelcast/jet/tests/snapshot/kafka/SnapshotKafkaTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.jet.tests.snapshot.kafka;
 
-import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.internal.util.UuidUtil;
 import com.hazelcast.jet.Jet;
 import com.hazelcast.jet.JetInstance;
@@ -64,7 +63,6 @@ public class SnapshotKafkaTest extends AbstractSoakTest {
     private static final int POLL_TIMEOUT = 1000;
     private static final int DELAY_AFTER_TEST_FINISHED_FACTOR = 60;
 
-    private ClientConfig stableClusterClientConfig;
     private JetInstance stableClusterClient;
 
     private String brokerUri;
@@ -95,8 +93,7 @@ public class SnapshotKafkaTest extends AbstractSoakTest {
         jobCount = propertyInt("jobCount", 2);
         countPerTicker = propertyInt("countPerTicker", DEFAULT_COUNTER_PER_TICKER);
 
-        stableClusterClientConfig = remoteClusterClientConfig();
-        stableClusterClient = Jet.newJetClient(stableClusterClientConfig);
+        stableClusterClient = Jet.newJetClient(remoteClusterClientConfig());
 
         ILogger producerLogger = getLogger(SnapshotTradeProducer.class);
         producerFuture = producerExecutorService.submit(() -> {
@@ -204,9 +201,12 @@ public class SnapshotKafkaTest extends AbstractSoakTest {
         }
     }
 
-    protected void teardown(Throwable t) throws Exception {
+    protected void teardown(Throwable t) {
         if (producerExecutorService != null) {
             producerExecutorService.shutdown();
+        }
+        if (stableClusterClient != null) {
+            stableClusterClient.shutdown();
         }
     }
 

--- a/soak-tests-common/src/main/java/com/hazelcast/jet/tests/common/AbstractSoakTest.java
+++ b/soak-tests-common/src/main/java/com/hazelcast/jet/tests/common/AbstractSoakTest.java
@@ -135,6 +135,10 @@ public abstract class AbstractSoakTest {
         return jet.getHazelcastInstance().getLoggingService().getLogger(clazz);
     }
 
+    protected static ILogger getLogger(JetInstance instance, Class clazz) {
+        return instance.getHazelcastInstance().getLoggingService().getLogger(clazz);
+    }
+
     protected static PredicateEx<EventJournalMapEvent<Long, Long>> filter(boolean odds) {
         PredicateEx<EventJournalMapEvent<Long, Long>> putEvents = mapPutEvents();
         return e -> putEvents.test(e) && (e.getNewValue() % 2 == (odds ? 1 : 0));


### PR DESCRIPTION
- Move the test to dynamic cluster
- Configure the test with EXACTLY_ONCE processing guarantee
- Submit the job to stable cluster also

1 hour run passed 
http://jenkins.hazelcast.com/job/jet-soak-tests/129/