### PR TITLE
While switching from odds to evens use the largest value in the queue to start the counter

### DIFF
--- a/job-management-test/src/main/java/com/hazelcast/jet/tests/management/VerificationProcessor.java
+++ b/job-management-test/src/main/java/com/hazelcast/jet/tests/management/VerificationProcessor.java
@@ -83,10 +83,11 @@ public final class VerificationProcessor extends AbstractProcessor {
         logger.info(String.format("restoreFromSnapshot odd: %b, counter: %d, size: %d, peek: %d",
                 odds, counter, queue.size(), queue.peek()));
 
-        if ((odds && !isOdd(counter)) || (!odds && isOdd(counter))) {
-            counter++;
+        if (!queue.isEmpty() && odds != isOdd(queue.peek())) {
+            counter = (long) queue.toArray()[queue.size()-1] + 1;
+            queue.clear();
+            logger.info(String.format("Switch from %b to %b, new counter: %d", !odds, odds, counter));
         }
-        queue.removeIf(v -> odds != isOdd(v));
     }
 
     private void consumeQueue() {


### PR DESCRIPTION
The scenario:
    job is processing the odd values 
    export snapshot called -> counter: 5 priorityQueue: 7, 9.
    job is now processing the even values
    restoreFromSnapshot increments the counter to 6 and clears the queue, the next even item is 10, 6 is filtered out by previous job.

With the change we first check if `restoreFromSnapshot` is called for a switch between old/even values, if so we use the largest value in the queue to set the verification counter.
