### PR TITLE
Improve code readability

### DIFF
--- a/early-results-test/src/main/java/com/hazelcast/jet/tests/earlyresults/EarlyResultsTest.java
+++ b/early-results-test/src/main/java/com/hazelcast/jet/tests/earlyresults/EarlyResultsTest.java
@@ -123,8 +123,8 @@ public class EarlyResultsTest extends AbstractSoakTest {
             if (result.start() > tickerWindow.nextWindowStart) {
                 logger.severe("Did not receive the final result for the previous window:\n" +
                         "Current result: " + result + "\n" +
-                        "Start index of tickerWindow=" + tickerWindow.nextWindowStart +
-                        ", start index of current result=" + result.start());
+                        "Expected window start: " + tickerWindow.nextWindowStart +
+                        ", actual window start: " + result.start());
             }
             if (result.isEarly()) {
                 assertTrue(result.getValue() <= windowSize);

--- a/early-results-test/src/main/java/com/hazelcast/jet/tests/earlyresults/TradeGenerator.java
+++ b/early-results-test/src/main/java/com/hazelcast/jet/tests/earlyresults/TradeGenerator.java
@@ -33,18 +33,18 @@ final class TradeGenerator {
 
     private final List<String> tickerList;
 
-    private final long produceThreshold;
+    private final long emitPeriod;
     private long timestamp;
     private long lastEmit = System.currentTimeMillis();
 
-    private TradeGenerator(int tradesPerSec) {
+    private TradeGenerator(int tradeBatchesPerSec) {
         this.tickerList = loadTickers();
-        this.produceThreshold = SECONDS.toMillis(1) / tradesPerSec;
+        this.emitPeriod = SECONDS.toMillis(1) / tradeBatchesPerSec;
     }
 
     private void generateTrades(TimestampedSourceBuffer<Map.Entry<String, Long>> buf) {
         long now = System.currentTimeMillis();
-        if (now - lastEmit > produceThreshold) {
+        if (now - lastEmit > emitPeriod) {
             tickerList.stream().map(ticker -> entry(ticker, timestamp)).forEach(trade -> buf.add(trade, timestamp));
             timestamp++;
             lastEmit = now;


### PR DESCRIPTION
Among other things, this PR renames the variables configured from a property file. It does not rename the properties themselves in order not to break existing configs, but these should be rename too for clarity