### PR TITLE
Rewrite early-result-test verification according to ordering contract

### DIFF
--- a/early-results-test/src/main/java/com/hazelcast/jet/tests/earlyresults/EarlyResultsTest.java
+++ b/early-results-test/src/main/java/com/hazelcast/jet/tests/earlyresults/EarlyResultsTest.java
@@ -114,8 +114,8 @@ public class EarlyResultsTest extends AbstractSoakTest {
         void verify(KeyedWindowResult<String, Long> result) {
             TickerWindow tickerWindow = tickerMap.computeIfAbsent(result.getKey(), k -> new TickerWindow());
 
-            assertFalse("Received a result for the previous window: " + result,
-                    result.start() < tickerWindow.start);
+            assertTrue("Received a result for the previous window: " + result,
+                    result.start() >= tickerWindow.start);
 
             if (result.start() > tickerWindow.start) {
                 assertTrue("Received a final result for the next window: " + result, result.isEarly());


### PR DESCRIPTION
- fails the test if receives a result for previous window
- fails the test if receives a final result for next window, does not fail if it is an early result.