### PR TITLE
Fix verification for cdc-source-test/snapshot-jms-source-test

### DIFF
--- a/cdc-source-test/src/main/java/com/hazelcast/jet/tests/cdc/source/VerificationProcessor.java
+++ b/cdc-source-test/src/main/java/com/hazelcast/jet/tests/cdc/source/VerificationProcessor.java
@@ -56,6 +56,7 @@ public class VerificationProcessor extends AbstractProcessor {
         int value = (Integer) item;
         queue.offer(value);
         // try to verify head of verification queue
+        long counterBeforeProcess = counter;
         for (Integer peeked; (peeked = queue.peek()) != null;) {
             if (peeked > counter) {
                 // the item might arrive later
@@ -67,10 +68,14 @@ public class VerificationProcessor extends AbstractProcessor {
                 // correct head of queue
                 queue.remove();
                 counter++;
-                map.put(name, counter);
-            } else if (peeked < counter) {
+            } else {
                 // duplicate key, ignore
+                logger.warning(String.format("[%s] Duplicate key %d, but counter was %d", name, peeked, counter));
+                queue.remove();
             }
+        }
+        if (counter != counterBeforeProcess) {
+            map.setAsync(name, counter);
         }
         if (queue.size() >= QUEUE_SIZE_LIMIT) {
             throw new AssertionError(String.format("[%s] Queue size exceeded while waiting for the next "

--- a/job-management-test/src/main/java/com/hazelcast/jet/tests/management/JobManagementTest.java
+++ b/job-management-test/src/main/java/com/hazelcast/jet/tests/management/JobManagementTest.java
@@ -24,7 +24,6 @@ import com.hazelcast.jet.JobStateSnapshot;
 import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.config.ProcessingGuarantee;
 import com.hazelcast.jet.pipeline.Pipeline;
-import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.Sources;
 import com.hazelcast.jet.tests.common.AbstractSoakTest;
 import com.hazelcast.map.IMap;
@@ -36,7 +35,6 @@ import static com.hazelcast.jet.Util.mapPutEvents;
 import static com.hazelcast.jet.core.JobStatus.RUNNING;
 import static com.hazelcast.jet.core.JobStatus.SUSPENDED;
 import static com.hazelcast.jet.pipeline.JournalInitialPosition.START_FROM_OLDEST;
-import static com.hazelcast.jet.pipeline.ServiceFactories.sharedService;
 import static com.hazelcast.jet.tests.common.Util.sleepMillis;
 import static com.hazelcast.jet.tests.common.Util.sleepMinutes;
 import static com.hazelcast.jet.tests.common.Util.sleepSeconds;
@@ -134,11 +132,9 @@ public class JobManagementTest extends AbstractSoakTest {
 
     private static Pipeline pipeline() {
         Pipeline p = Pipeline.create();
-        p.readFrom(Sources.mapJournal(SOURCE, START_FROM_OLDEST, mapEventNewValue(), mapPutEvents()))
+        p.readFrom(Sources.<Long, Long, Long>mapJournal(SOURCE, START_FROM_OLDEST, mapEventNewValue(), mapPutEvents()))
          .withoutTimestamps()
-         .groupingKey(l -> 0L)
-         .mapUsingService(sharedService(ctw -> null), (c, k, v) -> v)
-         .writeTo(Sinks.fromProcessor("sink", VerificationProcessor.supplier()));
+         .writeTo(VerificationProcessor.sink());
         return p;
     }
 

--- a/snapshot-jms-source-test/src/main/java/com/hazelcast/jet/tests/snapshot/jmssource/VerificationProcessor.java
+++ b/snapshot-jms-source-test/src/main/java/com/hazelcast/jet/tests/snapshot/jmssource/VerificationProcessor.java
@@ -58,6 +58,7 @@ public class VerificationProcessor extends AbstractProcessor {
         long value = (Long) item;
         queue.offer(value);
         // try to verify head of verification queue
+        long counterBeforeProcess = counter;
         for (Long peeked; (peeked = queue.peek()) != null; ) {
             if (peeked > counter) {
                 // the item might arrive later
@@ -69,12 +70,14 @@ public class VerificationProcessor extends AbstractProcessor {
                 // correct head of queue
                 queue.remove();
                 counter++;
-                map.put(name, counter);
             } else {
                 // duplicate key
                 logger.warning(String.format("[%s] Duplicate key %d, but counter was %d", name, peeked, counter));
                 queue.remove();
             }
+        }
+        if (counter != counterBeforeProcess) {
+            map.setAsync(name, counter);
         }
         if (queue.size() >= QUEUE_SIZE_LIMIT) {
             throw new AssertionError(String.format("[%s] Queue size exceeded while waiting for the next "


### PR DESCRIPTION
cdc-source verification processor was not removing the duplicate
key from the priority-queue. Also use `map.setAsync` instead of
`map.put` since it can fail with instance not active exception.

use `map.setAsync` instead of `map.put` for snapshot-jms-source-test
since it can fail with instance not active exception.

use SinkType.TOTAL_PARALLELISM_ONE for job-management sink
and get rid off manually grouping items to a single constant
key in the pipeline