### PR TITLE
Increase sleep between jobs from 100 to 1000 ms

### DIFF
--- a/attach-ml-model-test/src/main/java/com/hazelcast/jet/tests/attachml/AttachMLModelTest.java
+++ b/attach-ml-model-test/src/main/java/com/hazelcast/jet/tests/attachml/AttachMLModelTest.java
@@ -52,7 +52,7 @@ public class AttachMLModelTest extends AbstractSoakTest {
     private static final String ML_DATA_PATH_DEFAULT = "/home/ec2-user/ansible/15-minute-counts-sorted.csv";
     private static final String ML_LARGE_DATA_PATH_DEFAULT = "/home/ec2-user/ansible/ml_100mb";
 
-    private static final int PAUSE_BETWEEN_SMALL_FILE_JOBS = 100;
+    private static final int PAUSE_BETWEEN_SMALL_FILE_JOBS = 1_000;
     private static final int PAUSE_BETWEEN_LARGE_FILE_JOBS = 30_000;
     private static final int DELAY_AFTER_TEST_FINISHED = 120_000;
 

--- a/cooperative-map-cache-source-test/src/main/java/com/hazelcast/jet/tests/cooperativesource/CooperativeMapCacheSourceTest.java
+++ b/cooperative-map-cache-source-test/src/main/java/com/hazelcast/jet/tests/cooperativesource/CooperativeMapCacheSourceTest.java
@@ -61,7 +61,7 @@ public class CooperativeMapCacheSourceTest extends AbstractSoakTest {
 
     private static final int DEFAULT_THREAD_COUNT = 1;
 
-    private static final int PAUSE_BETWEEN_JOBS = 100;
+    private static final int PAUSE_BETWEEN_JOBS = 1_000;
 
     private int threadCount;
     /**

--- a/hdfs-test/src/main/java/com/hazelcast/jet/tests/hdfs/HdfsWordCountTest.java
+++ b/hdfs-test/src/main/java/com/hazelcast/jet/tests/hdfs/HdfsWordCountTest.java
@@ -60,7 +60,7 @@ public class HdfsWordCountTest extends AbstractSoakTest {
     private static final String TAB_STRING = "\t";
     private static final int DEFAULT_TOTAL = 4800000;
     private static final int DEFAULT_DISTINCT = 500000;
-    private static final int PAUSE_BETWEEN_JOBS = 100;
+    private static final int PAUSE_BETWEEN_JOBS = 1_000;
 
     private String hdfsUri;
     private String inputPath;

--- a/light-jobs-test/src/main/java/com/hazelcast/jet/tests/lightjobs/LightJobsTest.java
+++ b/light-jobs-test/src/main/java/com/hazelcast/jet/tests/lightjobs/LightJobsTest.java
@@ -40,8 +40,8 @@ public class LightJobsTest extends AbstractSoakTest {
     private static final String EXPECTED_FAIL_MESSAGE = "LightJobsTest - incorrectPipeline - expected exception";
 
     private static final int DEFAULT_ITEM_COUNT = 400;
-    private static final int DEFAULT_LOG_JOB_COUNT_THRESHOLD = 1000;
-    private static final int DEFAULT_SLEEP_BETWEEN_JOBS_MS = 100;
+    private static final int DEFAULT_LOG_JOB_COUNT_THRESHOLD = 1_000;
+    private static final int DEFAULT_SLEEP_BETWEEN_JOBS_MS = 1_000;
 
     private IMap<String, String> sourceBatchMap;
     private IMap<String, String> sourceJournalMap;

--- a/missing-permission-test/src/main/java/com/hazelcast/jet/tests/permissions/MissingPermissionTest.java
+++ b/missing-permission-test/src/main/java/com/hazelcast/jet/tests/permissions/MissingPermissionTest.java
@@ -34,7 +34,7 @@ public class MissingPermissionTest extends AbstractSoakTest {
 
     private static final int DEFAULT_ITEM_COUNT = 1_000;
     private static final int LOG_JOB_COUNT_THRESHOLD = 2_000;
-    private static final int DEFAULT_SLEEP_AFTER_TEST_MS = 100;
+    private static final int DEFAULT_SLEEP_AFTER_TEST_MS = 1_000;
     private static final boolean DEFAULT_RUN_ON_SECURED_CLUSTER = false;
 
     private IMap<Integer, Integer> sourceMap;


### PR DESCRIPTION
Because the light jobs speed up job submission also for regular jobs
this commit increases the time between 2 job submissions from 100 to
1000 ms. This makes the jobs submit at roughly same rate as before the
light jobs commit.