### PR TITLE
Improve deleteIndex in elastic test

### DIFF
--- a/elastic-test/src/main/java/com/hazelcast/jet/tests/elastic/ElasticTest.java
+++ b/elastic-test/src/main/java/com/hazelcast/jet/tests/elastic/ElasticTest.java
@@ -195,7 +195,6 @@ public class ElasticTest extends AbstractSoakTest {
 
     private void deleteIndex(int indexCounter) throws IOException {
         int counter = 0;
-        IOException exToLog = null;
         while (counter < 30) {
             try (RestHighLevelClient client = new RestHighLevelClient(
                     RestClient.builder(new HttpHost(elasticIp, 9200, "http")))) {
@@ -203,12 +202,11 @@ public class ElasticTest extends AbstractSoakTest {
                         new DeleteIndexRequest("elastictest-index" + indexCounter), RequestOptions.DEFAULT);
                 return;
             } catch (IOException ex) {
+                logger.info("elastictest-index" + indexCounter + " cannot be deleted, counter " + counter, ex);
                 counter++;
-                exToLog = ex;
                 sleepSeconds(5);
             }
         }
-        logger.info("elastictest-index" + indexCounter + " cannot be deleted.", exToLog);
     }
 
     private void clearSinkList(HazelcastInstance client) {

--- a/elastic-test/src/main/java/com/hazelcast/jet/tests/elastic/ElasticTest.java
+++ b/elastic-test/src/main/java/com/hazelcast/jet/tests/elastic/ElasticTest.java
@@ -194,10 +194,21 @@ public class ElasticTest extends AbstractSoakTest {
     }
 
     private void deleteIndex(int indexCounter) throws IOException {
-        try (RestHighLevelClient client = new RestHighLevelClient(
-                RestClient.builder(new HttpHost(elasticIp, 9200, "http")))) {
-            client.indices().delete(new DeleteIndexRequest("elastictest-index" + indexCounter), RequestOptions.DEFAULT);
+        int counter = 0;
+        IOException exToLog = null;
+        while (counter < 30) {
+            try (RestHighLevelClient client = new RestHighLevelClient(
+                    RestClient.builder(new HttpHost(elasticIp, 9200, "http")))) {
+                client.indices().delete(
+                        new DeleteIndexRequest("elastictest-index" + indexCounter), RequestOptions.DEFAULT);
+                return;
+            } catch (IOException ex) {
+                counter++;
+                exToLog = ex;
+                sleepSeconds(5);
+            }
         }
+        logger.info("elastictest-index" + indexCounter + " cannot be deleted.", exToLog);
     }
 
     private void clearSinkList(HazelcastInstance client) {


### PR DESCRIPTION
Soak test failed with `java.net.ConnectException: Timeout connecting to [/10.0.0.81:9200]` during `deleteIndex` - this PR adds retry to that method + just log if it failed and not fail the whole test.