### PR TITLE
Destroy the observables later in FileIngestionTest

### DIFF
--- a/file-ingestion-test/src/main/java/com/hazelcast/jet/tests/file/ingestion/FileIngestionTest.java
+++ b/file-ingestion-test/src/main/java/com/hazelcast/jet/tests/file/ingestion/FileIngestionTest.java
@@ -129,11 +129,12 @@ public class FileIngestionTest extends AbstractSoakTest {
                 } catch (Throwable t) {
                     logger.severe("Failure while verifying job: " + jobs[i].getName(), t);
                     throwableList.add(t);
-                } finally {
-                    observable.destroy();
                 }
             }
             sleepSeconds(sleepSeconds);
+            for (JobType jobType : jobTypes) {
+                client.getJet().getObservable(observableName(jobType, jobCount)).destroy();
+            }
             jobCount++;
             if (jobCount % 100 == 0) {
                 logger.info("Job count " + jobCount);


### PR DESCRIPTION
to make the test more resillient to the ringbuffer leak issue