### PR TITLE
Fix full restart in dynamic cluster

### DIFF
--- a/remote-controller-client/src/main/java/com/hazelcast/jet/tests/remote/RemoteControllerClient.java
+++ b/remote-controller-client/src/main/java/com/hazelcast/jet/tests/remote/RemoteControllerClient.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Iterables;
 import com.hazelcast.cluster.Member;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.function.SupplierEx;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.remotecontroller.Lang;
 import com.hazelcast.remotecontroller.RemoteController;
@@ -52,6 +53,8 @@ public final class RemoteControllerClient {
     private static final int DEFAULT_PORT = 9701;
     private static final int VERIFICATION_DURATION_GAP = 15;
     private static final int SLEEP_BETWEEN_CLUSTER_RESTART_SECONDS = 30;
+    private static final int ASSERTION_RETRY_COUNT = 120;
+    private static final String JAVA_PROCESS_CHECK = "jps | grep HazelcastMemberStarter | wc -l";
 
     private static int logCounter;
     private static ILogger logger;
@@ -118,8 +121,9 @@ public final class RemoteControllerClient {
         logger.info("Shutdown cluster");
         String host = member.getAddress().getHost();
         int port = member.getAddress().getPort();
-        call(member, jetHome + "/bin/jet-cluster-admin -a " + host + " -p " + port +
-                " -o shutdown -c jet-isolated -P jet-pass");
+        call(member, jetHome + "/bin/hz-cluster-admin -a " + host + " -p " + port
+                + " -o shutdown -c jet-isolated -P jet-pass");
+        assertClusterShutdown(members);
         sleepSeconds(1);
         members.forEach(m -> uncheckRun(() -> rollLogs(m, jetHome)));
     }
@@ -127,6 +131,7 @@ public final class RemoteControllerClient {
     private static void stop(Member member, String jetHome) throws Exception {
         logger.info("Stopping member[" + member + "]");
         call(member, "sudo initctl stop hazelcast-jet-isolated");
+        assertMemberStopped(member);
         rollLogs(member, jetHome);
         call(member, "rm -rf " + jetHome + "/hot-restart");
     }
@@ -142,17 +147,22 @@ public final class RemoteControllerClient {
     private static void start(Member member) throws Exception {
         logger.info("Starting member[" + member + "]");
         call(member, "sudo initctl start hazelcast-jet-isolated");
+        assertMemberStarted(member);
     }
 
-    private static void call(Member member, String command) throws Exception {
+    private static String call(Member member, String command) throws Exception {
         TTransport transport = new TSocket(member.getAddress().getHost(), DEFAULT_PORT);
         transport.open();
         TProtocol protocol = new TBinaryProtocol(transport);
         RemoteController.Client client = new RemoteController.Client(protocol);
-        String script = "import subprocess\nprocess = subprocess.call(['" + command + "'], shell=True)";
+        String script = "import subprocess\nresult = subprocess.check_output(['" + command + "'], shell=True)";
         Response response = client.executeOnController(null, script, Lang.PYTHON);
-        logger.info("The response of the command [" + command + "]: " + response);
+        byte[] result = response.getResult();
+        String resultString = result == null ? null : new String(result);
+        logger.info("The response of the command [" + command + "]: " +
+                response.success + " - " + response.message + " - " + resultString);
         transport.close();
+        return resultString;
     }
 
     private static void sleepMinutes(int minutes) throws InterruptedException {
@@ -161,5 +171,35 @@ public final class RemoteControllerClient {
 
     private static void sleepSeconds(int seconds) throws InterruptedException {
         SECONDS.sleep(seconds);
+    }
+
+    private static void assertMemberStarted(Member member) throws Exception {
+        assertWithRetry("Start member [" + member + "] assertion failed", () -> {
+            String result = call(member, JAVA_PROCESS_CHECK);
+            return result != null && result.trim().equals("1");
+        });
+    }
+
+    private static void assertMemberStopped(Member member) throws Exception {
+        assertWithRetry("Stop member [" + member + "] assertion failed", () -> {
+            String result = call(member, JAVA_PROCESS_CHECK);
+            return result != null && result.trim().equals("0");
+        });
+    }
+
+    private static void assertClusterShutdown(List<Member> members) throws Exception {
+        for (Member member : members) {
+            assertMemberStopped(member);
+        }
+    }
+
+    private static void assertWithRetry(String message, SupplierEx<Boolean> runnable) throws Exception {
+        for (int i = 0; i < ASSERTION_RETRY_COUNT; i++) {
+            if (runnable.get()) {
+                return;
+            }
+            sleepSeconds(1);
+        }
+        throw new AssertionError(message);
     }
 }


### PR DESCRIPTION
This PR:
- fix full restart in HZ 5.x dynamic cluster jet soak tests
- wait for member start/stop in remote controller client (as was originally implemented in https://github.com/hazelcast/hazelcast-jet-ansible-tests/pull/96)