### PR TITLE
ChangeRecord nullability fix

### DIFF
--- a/cdc-sink-test/src/main/java/com/hazelcast/jet/tests/cdc/sink/CdcSinkTest.java
+++ b/cdc-sink-test/src/main/java/com/hazelcast/jet/tests/cdc/sink/CdcSinkTest.java
@@ -233,10 +233,10 @@ public class CdcSinkTest extends AbstractSoakTest {
 
     private static ChangeRecord record(int messageId, Operation op, String key, String value) {
         Supplier<String> oldValue = op == INSERT || op == SYNC
-                ? () -> null
+                ? null
                 : () -> value;
         Supplier<String> newValue = op == DELETE
-                ? () -> null
+                ? null
                 : () -> value;
         return new ChangeRecordImpl(
                 0,

--- a/jdbc-test/pom.xml
+++ b/jdbc-test/pom.xml
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.16</version>
+            <version>8.0.29</version>
         </dependency>
         <dependency>
             <groupId>com.hazelcast.jet.tests</groupId>

--- a/snapshot-jdbc-test/pom.xml
+++ b/snapshot-jdbc-test/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.12</version>
+            <version>8.0.29</version>
         </dependency>
         <dependency>
             <groupId>com.hazelcast.jet.tests</groupId>


### PR DESCRIPTION
The recordPart suppliers should never return null; instead, supplier may be null.