### PR TITLE
Retry for timeout for deleting index in ElasticTest

### DIFF
--- a/elastic-test/src/main/java/com/hazelcast/jet/tests/elastic/ElasticTest.java
+++ b/elastic-test/src/main/java/com/hazelcast/jet/tests/elastic/ElasticTest.java
@@ -201,12 +201,13 @@ public class ElasticTest extends AbstractSoakTest {
                 client.indices().delete(
                         new DeleteIndexRequest("elastictest-index" + indexCounter), RequestOptions.DEFAULT);
                 return;
-            } catch (IOException ex) {
+            } catch (Exception ex) {
                 logger.info("elastictest-index" + indexCounter + " cannot be deleted, counter " + counter, ex);
                 counter++;
                 sleepSeconds(5);
             }
         }
+        throw new AssertionError("elastictest-index" + indexCounter + " cannot be deleted");
     }
 
     private void clearSinkList(HazelcastInstance client) {


### PR DESCRIPTION
ElasticTest failed due to timeout in connection to elastic but retry mechanism was implemented only for IOException. Following exception was thrown on client side:
```
ElasticsearchException[java.util.concurrent.ExecutionException: java.net.ConnectException: Timeout connecting to [/10.0.0.180:9200]]; nested: ExecutionException[java.net.ConnectException: Timeout connecting to [/10.0.0.180:9200]]; nested: ConnectException[Timeout connecting to [/10.0.0.180:9200]];
        at org.elasticsearch.client.RestHighLevelClient.performClientRequest(RestHighLevelClient.java:2695)
        at org.elasticsearch.client.RestHighLevelClient.internalPerformRequest(RestHighLevelClient.java:2171)
        at org.elasticsearch.client.RestHighLevelClient.performRequest(RestHighLevelClient.java:2137)
        at org.elasticsearch.client.RestHighLevelClient.performRequestAndParseEntity(RestHighLevelClient.java:2105)
        at org.elasticsearch.client.IndicesClient.delete(IndicesClient.java:109)
        at com.hazelcast.jet.tests.elastic.ElasticTest.deleteIndex(ElasticTest.java:201)
        at com.hazelcast.jet.tests.elastic.ElasticTest.test(ElasticTest.java:95)
        at com.hazelcast.jet.tests.common.AbstractSoakTest.testInternal(AbstractSoakTest.java:154)
        at com.hazelcast.jet.tests.common.AbstractSoakTest.run(AbstractSoakTest.java:89)
        at com.hazelcast.jet.tests.elastic.ElasticTest.main(ElasticTest.java:65)
        ...
```