### PR TITLE
Fix kafka tests

### DIFF
--- a/kafka-session-window-test/src/main/java/com/hazelcast/jet/tests/kafka/KafkaSessionWindowTest.java
+++ b/kafka-session-window-test/src/main/java/com/hazelcast/jet/tests/kafka/KafkaSessionWindowTest.java
@@ -31,6 +31,7 @@ import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.StreamStage;
 import com.hazelcast.jet.tests.common.AbstractSoakTest;
 import com.hazelcast.map.IMap;
+import java.time.Duration;
 import org.apache.kafka.common.serialization.LongDeserializer;
 import org.apache.kafka.common.serialization.LongSerializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
@@ -115,7 +116,6 @@ public class KafkaSessionWindowTest extends AbstractSoakTest {
         String previousProcessedUuid = "initialValue";
         IMap<String, String> itemProcessedMap = client.getMap(ITEM_PROCESSED_MAP);
         itemProcessedMap.put(ITEM_PROCESSED_MAP_KEY, previousProcessedUuid);
-        int iteration = 0;
         try {
             while (System.currentTimeMillis() - begin < durationInMillis) {
                 MINUTES.sleep(1);
@@ -127,13 +127,11 @@ public class KafkaSessionWindowTest extends AbstractSoakTest {
 
                 // check whether verification pipeline actually processed some items
                 // start to check this after 5minutes
-                if (iteration >= 4) {
+                if (System.currentTimeMillis() - begin > Duration.ofMinutes(5).toMillis()) {
                     String currentLastProcessedUuid = itemProcessedMap.get(ITEM_PROCESSED_MAP_KEY);
                     assertNotNull(currentLastProcessedUuid);
                     assertNotEquals(previousProcessedUuid, currentLastProcessedUuid);
                     previousProcessedUuid = currentLastProcessedUuid;
-                } else {
-                    iteration++;
                 }
             }
         } finally {

--- a/snapshot-kafka-test/src/main/java/com/hazelcast/jet/tests/snapshot/kafka/SnapshotKafkaTest.java
+++ b/snapshot-kafka-test/src/main/java/com/hazelcast/jet/tests/snapshot/kafka/SnapshotKafkaTest.java
@@ -34,6 +34,7 @@ import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.serialization.LongDeserializer;
 import org.apache.kafka.common.serialization.LongSerializer;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -128,7 +129,7 @@ public class SnapshotKafkaTest extends AbstractSoakTest {
         try {
             long begin = System.currentTimeMillis();
             while (System.currentTimeMillis() - begin < durationInMillis) {
-                ConsumerRecords<Long, Long> records = consumer.poll(POLL_TIMEOUT);
+                ConsumerRecords<Long, Long> records = consumer.poll(Duration.ofMillis(POLL_TIMEOUT));
                 records.iterator().forEachRemaining(r -> {
                             String topic = r.topic();
                             if (topic.contains(AT_LEAST_ONCE.name())) {
@@ -144,8 +145,12 @@ public class SnapshotKafkaTest extends AbstractSoakTest {
                             }
                         }
                 );
+                assertTrue(atLeastOnceVerifier.isRunning());
+                assertTrue(exactlyOnceVerifier.isRunning());
                 assertFalse(producerFuture.isDone());
             }
+            assertTrue(atLeastOnceVerifier.processedAnything());
+            assertTrue(exactlyOnceVerifier.processedAnything());
         } finally {
             logger.info("[" + name + "] Cancelling jobs...");
             consumer.close();

--- a/soak-tests-common/src/main/java/com/hazelcast/jet/tests/common/QueueVerifier.java
+++ b/soak-tests-common/src/main/java/com/hazelcast/jet/tests/common/QueueVerifier.java
@@ -81,6 +81,17 @@ public class QueueVerifier extends Thread {
             if (next == null) {
                 //Queue is empty, sleep
                 logger.info("Queue is empty");
+                // we need to check this also for next == null branch, otherwise we will not fail for getting null
+                // repeatedly
+                if (lastCheck == -1) {
+                    lastCheck = System.currentTimeMillis();
+                } else {
+                    if ((System.currentTimeMillis() - lastCheck) > TIMEOUT) {
+                        logger.info("No new item was received during the last " + TIMEOUT + "ms. Item was null.");
+                        //time is up
+                        running = false;
+                    }
+                }
                 sleepSeconds(WAIT_SLEEP_SECONDS);
             } else if (next == key) {
                 //Happy path
@@ -99,6 +110,7 @@ public class QueueVerifier extends Thread {
                 lastCheck = System.currentTimeMillis();
             } else if ((System.currentTimeMillis() - lastCheck) > TIMEOUT) {
                 //time is up
+                logger.info("No new item was received during the last " + TIMEOUT + "ms. Item was not null.");
                 running = false;
             } else {
                 //sleep for timeout
@@ -106,6 +118,14 @@ public class QueueVerifier extends Thread {
                 logger.info("key: " + key);
             }
         }
+    }
+
+    public boolean isRunning() {
+        return running;
+    }
+
+    public boolean processedAnything() {
+        return key > 0;
     }
 
     public void close() throws Exception {

--- a/stateful-map-test/src/main/java/com/hazelcast/jet/tests/stateful/KafkaSinkVerifier.java
+++ b/stateful-map-test/src/main/java/com/hazelcast/jet/tests/stateful/KafkaSinkVerifier.java
@@ -18,6 +18,7 @@ package com.hazelcast.jet.tests.stateful;
 
 import com.hazelcast.internal.util.UuidUtil;
 import com.hazelcast.logging.ILogger;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.PriorityQueue;
@@ -72,7 +73,7 @@ public class KafkaSinkVerifier {
         long lastInputTime = System.currentTimeMillis();
         while (!finished) {
             try {
-                ConsumerRecords<Long, Long> records = consumer.poll(POLL_TIMEOUT);
+                ConsumerRecords<Long, Long> records = consumer.poll(Duration.ofMillis(POLL_TIMEOUT));
                 for (ConsumerRecord<Long, Long> record : records) {
                     verificationQueue.add(record.key());
                     if (record.value() != 0) {

--- a/stateful-map-test/src/main/java/com/hazelcast/jet/tests/stateful/KafkaTradeProducer.java
+++ b/stateful-map-test/src/main/java/com/hazelcast/jet/tests/stateful/KafkaTradeProducer.java
@@ -48,6 +48,7 @@ import static java.util.concurrent.locks.LockSupport.parkNanos;
 public class KafkaTradeProducer implements AutoCloseable {
 
     private static final int PRODUCE_WAIT_TIMEOUT_MILLIS = 10_000;
+    private static final int MAX_WAIT_IN_FINISH_MS = 120_000;
 
     private final KafkaProducer<String, Long> producer;
     private final String topic;
@@ -128,7 +129,7 @@ public class KafkaTradeProducer implements AutoCloseable {
     public long finish() throws Exception {
         checkStatus();
         finished = true;
-        producerThread.join();
+        producerThread.join(MAX_WAIT_IN_FINISH_MS);
         checkStatus();
         return txId;
     }

--- a/stateful-map-test/src/main/java/com/hazelcast/jet/tests/stateful/StatefulMapTest.java
+++ b/stateful-map-test/src/main/java/com/hazelcast/jet/tests/stateful/StatefulMapTest.java
@@ -26,6 +26,7 @@ import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.StreamSource;
 import com.hazelcast.jet.pipeline.StreamStage;
 import com.hazelcast.jet.tests.common.AbstractSoakTest;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -170,7 +171,7 @@ public class StatefulMapTest extends AbstractSoakTest {
     }
 
     private long processTimeoutItems(String name, KafkaConsumer<Long, Long> txTimeoutConsumer) {
-        ConsumerRecords<Long, Long> records = txTimeoutConsumer.poll(POLL_TIMEOUT);
+        ConsumerRecords<Long, Long> records = txTimeoutConsumer.poll(Duration.ofMillis(POLL_TIMEOUT));
         for (ConsumerRecord<Long, Long> record : records) {
             if (record.value() != -1) {
                 throw new AssertionError(


### PR DESCRIPTION
Example job - https://jenkins.hazelcast.com/view/Jet%20-%20Misc/job/jet-soak-tests-ondrej/229/console 

Tested with `5.5.0-DEVEL-5` but it's the same as master. Only unrelated python tests is failing. I also tried to run it with `5.5.0-DEVEL-5` before kafka related changes in `hazelcast-jet-ansible` (i.e. when kafka is down) and all 3 tests failed (expected behavior.)