### PR TITLE
Include hazelcast java client standalone in the tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
     <properties>
         <jdk.version>17</jdk.version>
         <hazelcast.version>6.0.0-SNAPSHOT</hazelcast.version>
+        <hazelcast.java.client.version>5.5.1-SNAPSHOT</hazelcast.java.client.version>
         <mysql.version>8.0.29</mysql.version>
         <mongodb.version>4.8.1</mongodb.version>
         <main.basedir>${project.basedir}</main.basedir>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <properties>
         <jdk.version>17</jdk.version>
         <hazelcast.version>6.0.0-SNAPSHOT</hazelcast.version>
-        <hazelcast.java.client.version>5.5.1-SNAPSHOT</hazelcast.java.client.version>
+        <hazelcast.java.client.version>5.5.0-SNAPSHOT</hazelcast.java.client.version>
         <mysql.version>8.0.29</mysql.version>
         <mongodb.version>4.8.1</mongodb.version>
         <main.basedir>${project.basedir}</main.basedir>

--- a/subset-routing-test/pom.xml
+++ b/subset-routing-test/pom.xml
@@ -16,12 +16,43 @@
         <main.basedir>${project.parent.basedir}</main.basedir>
     </properties>
 
+    <profiles>
+        <!-- ==============================
+             1) The default Hazelcast (server) profile
+             ============================== -->
+        <profile>
+            <id>default-hazelcast</id>
+            <!-- Activate by default if no other profiles are chosen -->
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+
+            <dependencies>
+                <dependency>
+                    <groupId>com.hazelcast</groupId>
+                    <artifactId>hazelcast-enterprise</artifactId>
+                    <version>${hazelcast.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <!-- ==============================
+             2) The Java Client profile
+             ============================== -->
+        <profile>
+            <id>java-client</id>
+            <!-- Not active by default; you opt in via -P!default-hazelcast,java-client -->
+            <dependencies>
+                <dependency>
+                    <groupId>com.hazelcast</groupId>
+                    <artifactId>hazelcast-enterprise-java-client</artifactId>
+                    <version>${hazelcast.java.client.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
     <dependencies>
-        <dependency>
-            <groupId>com.hazelcast</groupId>
-            <artifactId>hazelcast-enterprise</artifactId>
-            <version>${hazelcast.version}</version>
-        </dependency>
         <dependency>
             <groupId>com.hazelcast.jet.tests</groupId>
             <artifactId>soak-tests-common</artifactId>

--- a/subset-routing-test/pom.xml
+++ b/subset-routing-test/pom.xml
@@ -17,7 +17,9 @@
     </properties>
 
     <dependencies>
-        <!-- 1) Hazelcast Enterprise (server) - default -->
+        <!-- We have here two dependencies which have similar packages class etc,
+         but shade plugin is configured to create tests jars for server and client separately -->
+        <!-- 1) Hazelcast Enterprise -->
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast-enterprise</artifactId>
@@ -130,7 +132,8 @@
                     </execution>
                 </executions>
             </plugin>
-            <!-- Add prefix "original-" to the main jar (without dependencies) as this prefix is used in job to run soaks tests (otherwise it will be copied and run) -->
+            <!-- Add prefix "original-" to the main jar (without dependencies) as this prefix is used in job
+            to run soaks tests (otherwise it will be copied and run) -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>

--- a/subset-routing-test/pom.xml
+++ b/subset-routing-test/pom.xml
@@ -24,12 +24,11 @@
             <version>${hazelcast.version}</version>
         </dependency>
 
-        <!-- 2) Hazelcast Enterprise Java Client - not on the default runtime classpath -->
+        <!-- 2) Hazelcast Enterprise Java Client -->
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast-enterprise-java-client</artifactId>
             <version>${hazelcast.java.client.version}</version>
-            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/subset-routing-test/pom.xml
+++ b/subset-routing-test/pom.xml
@@ -16,43 +16,22 @@
         <main.basedir>${project.parent.basedir}</main.basedir>
     </properties>
 
-    <profiles>
-        <!-- ==============================
-             1) The default Hazelcast (server) profile
-             ============================== -->
-        <profile>
-            <id>default-hazelcast</id>
-            <!-- Activate by default if no other profiles are chosen -->
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-
-            <dependencies>
-                <dependency>
-                    <groupId>com.hazelcast</groupId>
-                    <artifactId>hazelcast-enterprise</artifactId>
-                    <version>${hazelcast.version}</version>
-                </dependency>
-            </dependencies>
-        </profile>
-
-        <!-- ==============================
-             2) The Java Client profile
-             ============================== -->
-        <profile>
-            <id>java-client</id>
-            <!-- Not active by default; you opt in via -P!default-hazelcast,java-client -->
-            <dependencies>
-                <dependency>
-                    <groupId>com.hazelcast</groupId>
-                    <artifactId>hazelcast-enterprise-java-client</artifactId>
-                    <version>${hazelcast.java.client.version}</version>
-                </dependency>
-            </dependencies>
-        </profile>
-    </profiles>
-
     <dependencies>
+        <!-- 1) Hazelcast Enterprise (server) - default -->
+        <dependency>
+            <groupId>com.hazelcast</groupId>
+            <artifactId>hazelcast-enterprise</artifactId>
+            <version>${hazelcast.version}</version>
+        </dependency>
+
+        <!-- 2) Hazelcast Enterprise Java Client - not on the default runtime classpath -->
+        <dependency>
+            <groupId>com.hazelcast</groupId>
+            <artifactId>hazelcast-enterprise-java-client</artifactId>
+            <version>${hazelcast.java.client.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
         <dependency>
             <groupId>com.hazelcast.jet.tests</groupId>
             <artifactId>soak-tests-common</artifactId>
@@ -85,38 +64,91 @@
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>${maven.shade.plugin.version}</version>
                 <executions>
+                    <!-- 1) JAR with hazelcast-enterprise (exclude client) -->
                     <execution>
+                        <id>shade-hz</id>
                         <phase>package</phase>
                         <goals>
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <outputFile>${project.build.directory}/${project.artifactId}-hz-${project.version}.jar</outputFile>
+                            <artifactSet>
+                                <includes>
+                                    <include>*:*</include>
+                                </includes>
+                                <excludes>
+                                    <exclude>com.hazelcast:hazelcast</exclude>
+                                    <exclude>com.hazelcast:hazelcast-enterprise-java-client</exclude>
+                                </excludes>
+                            </artifactSet>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
                             <transformers>
                                 <transformer
                                         implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                                 <transformer
                                         implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <manifestEntries>
-                                        <Main-Class>com.hazelcast.jet.tests.client.subset.routing.SubsetRoutingTest</Main-Class>
+                                        <Main-Class>com.hazelcast.jet.tests.client.subset.routing.SubsetRoutingTest
+                                        </Main-Class>
                                     </manifestEntries>
                                 </transformer>
                             </transformers>
-                            <createDependencyReducedPom>false</createDependencyReducedPom>
-                            <filters>
-                                <filter>
-                                    <artifact>*:*</artifact>
-                                </filter>
-                            </filters>
+                        </configuration>
+                    </execution>
+
+                    <!-- 2) JAR with hazelcast-enterprise-java-client (exclude hazelcast enterprise) -->
+                    <execution>
+                        <id>shade-client</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <outputFile>${project.build.directory}/${project.artifactId}-standalone-client-${project.version}.jar</outputFile>
                             <artifactSet>
-                                <excludes>
-                                    <!-- Exclude OS -->
-                                    <exclude>com.hazelcast:hazelcast</exclude>
-                                </excludes>
                                 <includes>
-                                    <!-- For client tests we need dependencies to hazelcast, etc -->
                                     <include>*:*</include>
                                 </includes>
+                                <excludes>
+                                    <exclude>com.hazelcast:hazelcast</exclude>
+                                    <exclude>com.hazelcast:hazelcast-enterprise</exclude>
+                                </excludes>
                             </artifactSet>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <transformers>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <manifestEntries>
+                                        <Main-Class>com.hazelcast.jet.tests.client.subset.routing.SubsetRoutingTest
+                                        </Main-Class>
+                                    </manifestEntries>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- Add prefix "original-" to the main jar (without dependencies) as this prefix is used in job to run soaks tests (otherwise it will be copied and run) -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>rename-after-install</id>
+                        <phase>install</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <move
+                                        file="${project.build.directory}/${project.build.finalName}.jar"
+                                        tofile="${project.build.directory}/original-${project.build.finalName}.jar"/>
+                            </target>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
I've included both dependencies of `hazelcast-enterprise` and `hazelcast-enterprise-java-client` in one project but final tests-jars are created with proper dependencies.

Ansible PR: https://github.com/hazelcast/hazelcast-jet-ansible/pull/145

Run: https://jenkins.hazelcast.com/job/jet-soak-tests-standalone/34/console
Note: Shown as failed because I forgot to change the final check if something was failed.