### PR TITLE
Relabel `master` from `6.0-SNAPSHOT` to `5.6-SNAPSHOT` [CTT-504]

### DIFF
--- a/async-transform-test/pom.xml
+++ b/async-transform-test/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
         <groupId>com.hazelcast.jet.tests</groupId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/attach-ml-model-test/pom.xml
+++ b/attach-ml-model-test/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
         <groupId>com.hazelcast.jet.tests</groupId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/cdc-sink-test/pom.xml
+++ b/cdc-sink-test/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.hazelcast.jet.tests</groupId>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/cdc-source-test/pom.xml
+++ b/cdc-source-test/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.hazelcast.jet.tests</groupId>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/cooperative-map-cache-source-test/pom.xml
+++ b/cooperative-map-cache-source-test/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.hazelcast.jet.tests</groupId>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/early-results-test/pom.xml
+++ b/early-results-test/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
         <groupId>com.hazelcast.jet.tests</groupId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/elastic-test/pom.xml
+++ b/elastic-test/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
         <groupId>com.hazelcast.jet.tests</groupId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
     </parent>
     <properties>
         <main.basedir>${project.parent.basedir}</main.basedir>

--- a/event-journal-test/pom.xml
+++ b/event-journal-test/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
         <groupId>com.hazelcast.jet.tests</groupId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/file-ingestion-test/pom.xml
+++ b/file-ingestion-test/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.hazelcast.jet.tests</groupId>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
     </parent>
 
 

--- a/generic-map-store-test/pom.xml
+++ b/generic-map-store-test/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.hazelcast.jet.tests</groupId>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>generic-map-store-test</artifactId>

--- a/grpc-test/pom.xml
+++ b/grpc-test/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
         <groupId>com.hazelcast.jet.tests</groupId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
     </parent>
     <properties>
         <main.basedir>${project.parent.basedir}</main.basedir>

--- a/hdfs-test/pom.xml
+++ b/hdfs-test/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.hazelcast.jet.tests</groupId>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
     </parent>
 
 

--- a/isolated-jobs-test/pom.xml
+++ b/isolated-jobs-test/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.hazelcast.jet.tests</groupId>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>isolated-jobs-test</artifactId>

--- a/jar-submission-module/jar-submission-job/pom.xml
+++ b/jar-submission-module/jar-submission-job/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>jar-submission-module</artifactId>
         <groupId>com.hazelcast.jet.tests</groupId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/jar-submission-module/jar-submission-test/pom.xml
+++ b/jar-submission-module/jar-submission-test/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>jar-submission-module</artifactId>
         <groupId>com.hazelcast.jet.tests</groupId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/jar-submission-module/pom.xml
+++ b/jar-submission-module/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
         <groupId>com.hazelcast.jet.tests</groupId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jar-submission-module</artifactId>

--- a/jdbc-test/pom.xml
+++ b/jdbc-test/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
         <groupId>com.hazelcast.jet.tests</groupId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
     </parent>
     <properties>
         <main.basedir>${project.parent.basedir}</main.basedir>

--- a/jms-test/pom.xml
+++ b/jms-test/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
         <groupId>com.hazelcast.jet.tests</groupId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/job-level-serializers-test/pom.xml
+++ b/job-level-serializers-test/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
         <groupId>com.hazelcast.jet.tests</groupId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/job-management-test/pom.xml
+++ b/job-management-test/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
         <groupId>com.hazelcast.jet.tests</groupId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/kafka-session-window-test/pom.xml
+++ b/kafka-session-window-test/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.hazelcast.jet.tests</groupId>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/kinesis-test/pom.xml
+++ b/kinesis-test/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.hazelcast.jet.tests</groupId>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/large-snapshot-chunk-test/pom.xml
+++ b/large-snapshot-chunk-test/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
         <groupId>com.hazelcast.jet.tests</groupId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/light-jobs-test/pom.xml
+++ b/light-jobs-test/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
         <groupId>com.hazelcast.jet.tests</groupId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/missing-permission-test/pom.xml
+++ b/missing-permission-test/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
         <groupId>com.hazelcast.jet.tests</groupId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/mongo-long-stream-test/pom.xml
+++ b/mongo-long-stream-test/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
         <groupId>com.hazelcast.jet.tests</groupId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
     </parent>
     <properties>
         <main.basedir>${project.parent.basedir}</main.basedir>

--- a/mongo-sql-test/pom.xml
+++ b/mongo-sql-test/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
         <groupId>com.hazelcast.jet.tests</groupId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
     </parent>
     <properties>
         <main.basedir>${project.parent.basedir}</main.basedir>

--- a/mongo-test/pom.xml
+++ b/mongo-test/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
         <groupId>com.hazelcast.jet.tests</groupId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
     </parent>
     <properties>
         <main.basedir>${project.parent.basedir}</main.basedir>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.hazelcast.jet.tests</groupId>
     <artifactId>hazelcast-jet-ansible-tests</artifactId>
     <packaging>pom</packaging>
-    <version>6.0.0-SNAPSHOT</version>
+    <version>5.6.0-SNAPSHOT</version>
     <description>Soak Tests for Hazelcast Jet</description>
     <modules>
         <module>remote-controller-client</module>
@@ -17,7 +17,7 @@
 
     <properties>
         <jdk.version>17</jdk.version>
-        <hazelcast.version>6.0.0-SNAPSHOT</hazelcast.version>
+        <hazelcast.version>5.6.0-SNAPSHOT</hazelcast.version>
         <mysql.version>8.0.29</mysql.version>
         <mongodb.version>4.8.1</mongodb.version>
         <main.basedir>${project.basedir}</main.basedir>

--- a/python-test/pom.xml
+++ b/python-test/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
         <groupId>com.hazelcast.jet.tests</groupId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/remote-controller-client/pom.xml
+++ b/remote-controller-client/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
         <groupId>com.hazelcast.jet.tests</groupId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/return-result-to-caller-test/pom.xml
+++ b/return-result-to-caller-test/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
         <groupId>com.hazelcast.jet.tests</groupId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/rolling-aggregate-test/pom.xml
+++ b/rolling-aggregate-test/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
         <groupId>com.hazelcast.jet.tests</groupId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/s3-test/pom.xml
+++ b/s3-test/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.hazelcast.jet.tests</groupId>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
     </parent>
 
 

--- a/snapshot-file-test/pom.xml
+++ b/snapshot-file-test/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.hazelcast.jet.tests</groupId>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/snapshot-jdbc-test/pom.xml
+++ b/snapshot-jdbc-test/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.hazelcast.jet.tests</groupId>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/snapshot-jms-sink-test/pom.xml
+++ b/snapshot-jms-sink-test/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.hazelcast.jet.tests</groupId>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/snapshot-jms-source-test/pom.xml
+++ b/snapshot-jms-source-test/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
         <groupId>com.hazelcast.jet.tests</groupId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/snapshot-kafka-test/pom.xml
+++ b/snapshot-kafka-test/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
         <groupId>com.hazelcast.jet.tests</groupId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/soak-tests-common-sql/pom.xml
+++ b/soak-tests-common-sql/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
         <groupId>com.hazelcast.jet.tests</groupId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/soak-tests-common/pom.xml
+++ b/soak-tests-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
         <groupId>com.hazelcast.jet.tests</groupId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/sort-test/pom.xml
+++ b/sort-test/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
         <groupId>com.hazelcast.jet.tests</groupId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/sql-map-json-test/pom.xml
+++ b/sql-map-json-test/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.hazelcast.jet.tests</groupId>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/sql-map-test/pom.xml
+++ b/sql-map-test/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.hazelcast.jet.tests</groupId>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/sql-stream-to-stream-fault-tolerance-test/pom.xml
+++ b/sql-stream-to-stream-fault-tolerance-test/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.hazelcast.jet.tests</groupId>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>sql-stream-to-stream-fault-tolerance-test</artifactId>

--- a/sql-stream-to-stream-join-test/pom.xml
+++ b/sql-stream-to-stream-join-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
         <groupId>com.hazelcast.jet.tests</groupId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/sql-tumble-window-test/pom.xml
+++ b/sql-tumble-window-test/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
         <groupId>com.hazelcast.jet.tests</groupId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/stateful-map-test/pom.xml
+++ b/stateful-map-test/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
         <groupId>com.hazelcast.jet.tests</groupId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/subset-routing-test/pom.xml
+++ b/subset-routing-test/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.hazelcast.jet.tests</groupId>
         <artifactId>hazelcast-jet-ansible-tests</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>subset-routing-test</artifactId>


### PR DESCRIPTION
Renames the version on `master` from `6.0-SNAPSHOT` to `5.6-SNAPSHOT`.

Supports https://github.com/hazelcast/hazelcast-mono/pull/4852

Fixes: [CTT-504](https://hazelcast.atlassian.net/browse/CTT-504)

[CTT-504]: https://hazelcast.atlassian.net/browse/CTT-504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ