### PR TITLE
Fix Master node is Null [QE-94]

### DIFF
--- a/sql-stream-to-stream-fault-tolerance-test/src/main/java/com/hazelcast/jet/tests/sql/s2sjoin/ft/SqlStreamToStreamFaultToleranceTest.java
+++ b/sql-stream-to-stream-fault-tolerance-test/src/main/java/com/hazelcast/jet/tests/sql/s2sjoin/ft/SqlStreamToStreamFaultToleranceTest.java
@@ -259,7 +259,7 @@ public class SqlStreamToStreamFaultToleranceTest extends AbstractJetSoakTest {
                     continue;
                 }
                 sqlJob.cancel();
-                logger.info("Sql job located without exception");
+                logger.severe("Exception during trying to get or cancel the job");
                 break;
             } catch (RuntimeException e) {
                 try {

--- a/sql-stream-to-stream-fault-tolerance-test/src/main/java/com/hazelcast/jet/tests/sql/s2sjoin/ft/SqlStreamToStreamFaultToleranceTest.java
+++ b/sql-stream-to-stream-fault-tolerance-test/src/main/java/com/hazelcast/jet/tests/sql/s2sjoin/ft/SqlStreamToStreamFaultToleranceTest.java
@@ -252,10 +252,13 @@ public class SqlStreamToStreamFaultToleranceTest extends AbstractJetSoakTest {
     }
 
     private void cancelJobWithRetry(HazelcastInstance client, String sqlName) {
-        Job sqlJob = null;
         for  (int i = 0; i < RETRY_CANCEL_JOB_COUNT; i++) {
             try {
-                sqlJob = client.getJet().getJob(sqlName);
+                Job sqlJob = client.getJet().getJob(sqlName);
+                if (sqlJob == null || sqlJob.getStatus().isTerminal()){
+                    continue;
+                }
+                sqlJob.cancel();
                 logger.info("Sql job located without exception");
                 break;
             } catch (RuntimeException e) {
@@ -267,10 +270,6 @@ public class SqlStreamToStreamFaultToleranceTest extends AbstractJetSoakTest {
                     throw new RuntimeException("Interrupted during retry", ie);
                 }
             }
-        }
-
-        if (sqlJob != null && !sqlJob.getStatus().isTerminal()) {
-            sqlJob.cancel();
         }
     }
 }


### PR DESCRIPTION
I can see in the end of logs it got the job correctly but had failed to cancel it

both calls for getJob and cancel should be inside same try/catch loop

17:55:01.959 [[32m INFO[0m] [[34mc.h.j.t.s.s.f.KafkaSinkVerifier[0m] [Stable-SqlStreamToStreamFaultToleranceTest] Processed correctly item 17260000
17:55:58.541 [[32m INFO[0m] [[34mc.h.j.t.s.s.f.SqlStreamToStreamFaultToleranceTest[0m] hz.client_1 [jet-isolated] [5.5.8-SNAPSHOT] Sql job located without exception
17:55:59.023 [[31mERROR[0m] [[34mc.h.j.t.s.s.f.SqlStreamToStreamFaultToleranceTest[0m] hz.client_1 [jet-isolated] [5.5.8-SNAPSHOT] Exception in Dynamic-SqlStreamToStreamFaultToleranceTest
[31mjava.lang.RuntimeException: com.hazelcast.jet.JetException: Cannot query list of job IDs by name on non-master node. Master address: null
	at com.hazelcast.jet.impl.client.protocol.task.JetGetJobIdsMessageTask.lambda$reduce$2(JetGetJobIdsMessageTask.java:90)
	at java.util.stream.Collectors.lambda$uniqKeysMapAccumulator$1(Collectors.java:180)
	at java.util.stream.ReduceOps$3ReducingSink.accept(ReduceOps.java:169)
	at java.util.HashMap$EntrySpliterator.forEachRemaining(HashMap.java:1850)
 