### PR TITLE
Migrate Jet Kinesis extension to from deprecated AWS SDK v1 -> v2 [CTT-1106]

### DIFF
--- a/kinesis-test/src/main/java/com/hazelcast/jet/tests/kinesis/Helper.java
+++ b/kinesis-test/src/main/java/com/hazelcast/jet/tests/kinesis/Helper.java
@@ -16,17 +16,19 @@
 
 package com.hazelcast.jet.tests.kinesis;
 
-import com.hazelcast.shaded.com.amazonaws.SdkClientException;
-import com.hazelcast.shaded.com.amazonaws.services.kinesis.AmazonKinesisAsync;
-import com.hazelcast.shaded.com.amazonaws.services.kinesis.model.CreateStreamRequest;
-import com.hazelcast.shaded.com.amazonaws.services.kinesis.model.DescribeStreamSummaryRequest;
-import com.hazelcast.shaded.com.amazonaws.services.kinesis.model.ExpiredNextTokenException;
-import com.hazelcast.shaded.com.amazonaws.services.kinesis.model.InvalidArgumentException;
-import com.hazelcast.shaded.com.amazonaws.services.kinesis.model.LimitExceededException;
-import com.hazelcast.shaded.com.amazonaws.services.kinesis.model.ResourceInUseException;
-import com.hazelcast.shaded.com.amazonaws.services.kinesis.model.ResourceNotFoundException;
-import com.hazelcast.shaded.com.amazonaws.services.kinesis.model.StreamDescriptionSummary;
-import com.hazelcast.shaded.com.amazonaws.services.kinesis.model.StreamStatus;
+import com.hazelcast.shaded.software.amazon.awssdk.core.exception.SdkClientException;
+import com.hazelcast.shaded.software.amazon.awssdk.services.kinesis.KinesisAsyncClient;
+import com.hazelcast.shaded.software.amazon.awssdk.services.kinesis.model.CreateStreamRequest;
+import com.hazelcast.shaded.software.amazon.awssdk.services.kinesis.model.DeleteStreamRequest;
+import com.hazelcast.shaded.software.amazon.awssdk.services.kinesis.model.DescribeStreamSummaryRequest;
+import com.hazelcast.shaded.software.amazon.awssdk.services.kinesis.model.ExpiredNextTokenException;
+import com.hazelcast.shaded.software.amazon.awssdk.services.kinesis.model.InvalidArgumentException;
+import com.hazelcast.shaded.software.amazon.awssdk.services.kinesis.model.LimitExceededException;
+import com.hazelcast.shaded.software.amazon.awssdk.services.kinesis.model.ListStreamsRequest;
+import com.hazelcast.shaded.software.amazon.awssdk.services.kinesis.model.ResourceInUseException;
+import com.hazelcast.shaded.software.amazon.awssdk.services.kinesis.model.ResourceNotFoundException;
+import com.hazelcast.shaded.software.amazon.awssdk.services.kinesis.model.StreamDescriptionSummary;
+import com.hazelcast.shaded.software.amazon.awssdk.services.kinesis.model.StreamStatus;
 import com.hazelcast.jet.JetException;
 import com.hazelcast.jet.retry.IntervalFunction;
 import com.hazelcast.jet.retry.RetryStrategies;
@@ -37,6 +39,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.jet.impl.util.ExceptionUtil.rethrow;
@@ -49,10 +52,10 @@ public class Helper {
             .intervalFunction(IntervalFunction.exponentialBackoffWithCap(250L, 2.0, 1000L))
             .build();
 
-    private final AmazonKinesisAsync kinesis;
+    private final KinesisAsyncClient kinesis;
     private final ILogger logger;
 
-    Helper(AmazonKinesisAsync kinesis, ILogger logger) {
+    Helper(KinesisAsyncClient kinesis, ILogger logger) {
         this.kinesis = kinesis;
         this.logger = logger;
     }
@@ -63,10 +66,11 @@ public class Helper {
         }
 
         callSafely(() -> {
-            CreateStreamRequest request = new CreateStreamRequest();
-            request.setShardCount(shardCount);
-            request.setStreamName(stream);
-            return kinesis.createStream(request);
+            CreateStreamRequest request = CreateStreamRequest.builder()
+                    .shardCount(shardCount)
+                    .streamName(stream)
+                    .build();
+            return kinesis.createStream(request).join();
         }, format("stream[%s] creation", stream));
 
         waitForStreamToActivate(stream);
@@ -74,13 +78,15 @@ public class Helper {
 
     public void deleteStream(String stream) {
         if (streamExists(stream)) {
-            callSafely(() -> kinesis.deleteStream(stream), format("stream[%s] deletion", stream));
+            callSafely(() -> kinesis.deleteStream(
+                    DeleteStreamRequest.builder().streamName(stream).build()
+            ).join(), format("stream[%s] deletion", stream));
             waitForStreamToDisappear(stream);
         }
     }
 
     private List<String> listStreams() {
-        return kinesis.listStreams().getStreamNames();
+        return kinesis.listStreams(ListStreamsRequest.builder().build()).join().streamNames();
     }
 
     private boolean streamExists(String stream) {
@@ -121,13 +127,13 @@ public class Helper {
     }
 
     private StreamStatus getStreamStatus(String stream) {
-        DescribeStreamSummaryRequest request = new DescribeStreamSummaryRequest();
-        request.setStreamName(stream);
+        DescribeStreamSummaryRequest request = DescribeStreamSummaryRequest.builder()
+                .streamName(stream)
+                .build();
 
-        StreamDescriptionSummary description = kinesis.describeStreamSummary(request).getStreamDescriptionSummary();
-        String statusString = description.getStreamStatus();
-
-        return StreamStatus.valueOf(statusString);
+        StreamDescriptionSummary description = kinesis.describeStreamSummary(request)
+                .join().streamDescriptionSummary();
+        return description.streamStatus();
     }
 
     private <T> T callSafely(Callable<T> callable, String action) {
@@ -135,35 +141,41 @@ public class Helper {
         while (true) {
             try {
                 return callable.call();
-            } catch (LimitExceededException lee) {
-                String message = "The requested resource exceeds the maximum number allowed, " +
-                        "or the number of concurrent stream requests exceeds the maximum number allowed. " +
-                        "Will retry. The action: " + action;
-                logger.warning(message, lee);
-            } catch (ExpiredNextTokenException ente) {
-                String message = "The pagination token passed to the operation is expired. " +
-                        "Will retry. The action: " + action;
-                logger.warning(message, ente);
-            } catch (ResourceInUseException riue) {
-                String message = "The resource is not available for this operation. For successful operation, the " +
-                        "resource must be in the ACTIVE state. Will retry. The action: " + action;
-                logger.warning(message, riue);
-            } catch (ResourceNotFoundException rnfe) {
-                String message = "The requested resource could not be found. " +
-                        "The stream might not be specified correctly. The action: " + action;
-                throw new JetException(message, rnfe);
-            } catch (InvalidArgumentException iae) {
-                String message = "A specified parameter exceeds its restrictions, is not supported, or can't be used." +
-                        " The action: " + action;
-                throw new JetException(message, iae);
-            } catch (SdkClientException sce) {
-                String message = "Amazon SDK failure, ignoring and retrying. The action: " + action;
-                logger.warning(message, sce);
             } catch (Exception e) {
-                throw rethrow(e);
+                // CompletableFuture.join() wraps exceptions in CompletionException, unwrap to handle the actual cause
+                handleException(e instanceof CompletionException && e.getCause() != null ? e.getCause() : e, action);
             }
-
             wait(++attempt, action);
+        }
+    }
+
+    private void handleException(Throwable e, String action) {
+        if (e instanceof LimitExceededException) {
+            String message = "The requested resource exceeds the maximum number allowed, " +
+                    "or the number of concurrent stream requests exceeds the maximum number allowed. " +
+                    "Will retry. The action: " + action;
+            logger.warning(message, e);
+        } else if (e instanceof ExpiredNextTokenException) {
+            String message = "The pagination token passed to the operation is expired. " +
+                    "Will retry. The action: " + action;
+            logger.warning(message, e);
+        } else if (e instanceof ResourceInUseException) {
+            String message = "The resource is not available for this operation. For successful operation, the " +
+                    "resource must be in the ACTIVE state. Will retry. The action: " + action;
+            logger.warning(message, e);
+        } else if (e instanceof ResourceNotFoundException) {
+            String message = "The requested resource could not be found. " +
+                    "The stream might not be specified correctly. The action: " + action;
+            throw new JetException(message, e);
+        } else if (e instanceof InvalidArgumentException) {
+            String message = "A specified parameter exceeds its restrictions, is not supported, or can't be used." +
+                    " The action: " + action;
+            throw new JetException(message, e);
+        } else if (e instanceof SdkClientException) {
+            String message = "Amazon SDK failure, ignoring and retrying. The action: " + action;
+            logger.warning(message, e);
+        } else {
+            throw rethrow(e);
         }
     }
 

--- a/kinesis-test/src/main/java/com/hazelcast/jet/tests/kinesis/KinesisTest.java
+++ b/kinesis-test/src/main/java/com/hazelcast/jet/tests/kinesis/KinesisTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.jet.tests.kinesis;
 
-import com.amazonaws.SDKGlobalConfiguration;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.jet.Job;
 import com.hazelcast.jet.config.JobConfig;
@@ -30,7 +29,7 @@ import com.hazelcast.jet.pipeline.SourceBuilder;
 import com.hazelcast.jet.pipeline.StreamSource;
 import com.hazelcast.jet.tests.common.AbstractJetSoakTest;
 
-import com.hazelcast.shaded.com.amazonaws.regions.Regions;
+import com.hazelcast.shaded.software.amazon.awssdk.regions.Region;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -69,7 +68,6 @@ public class KinesisTest extends AbstractJetSoakTest {
     private boolean testFailed;
 
     public static void main(String[] args) throws Exception {
-        System.setProperty(SDKGlobalConfiguration.AWS_CBOR_DISABLE_SYSTEM_PROPERTY, "true");
         new KinesisTest().run(args);
     }
 
@@ -77,7 +75,7 @@ public class KinesisTest extends AbstractJetSoakTest {
     protected void init(HazelcastInstance client) {
         awsConfig = new AwsConfig()
                 .withEndpoint(property("endpoint", "http://localhost:4566"))
-                .withRegion(Regions.US_EAST_1.getName())
+                .withRegion(Region.US_EAST_1.id())
                 .withCredentials(property("accessKey", "accessKey"), property("secretKey", "secretKey"));
 
         shardCount = propertyInt("shardCount", DEFAULT_SHARD_COUNT);

--- a/remote-controller-client/pom.xml
+++ b/remote-controller-client/pom.xml
@@ -14,7 +14,7 @@
 
     <properties>
         <main.basedir>${project.parent.basedir}</main.basedir>
-        <remote.controller.version>0.4-SNAPSHOT</remote.controller.version>
+        <remote.controller.version>0.8-SNAPSHOT</remote.controller.version>
     </properties>
 
     <dependencies>
@@ -40,7 +40,6 @@
             <version>${hazelcast.version}</version>
         </dependency>
     </dependencies>
-
     <build>
         <plugins>
             <plugin>
@@ -106,4 +105,29 @@
             </plugin>
         </plugins>
     </build>
+
+    <repositories>
+        <repository>
+            <id>hazelcast-private-repository</id>
+            <name>Hazelcast Private Repository</name>
+            <url>https://repository.hazelcast.com/release/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>hazelcast-private-snapshot-repository</id>
+            <name>Hazelcast Private Repository</name>
+            <url>https://repository.hazelcast.com/snapshot/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
 </project>

--- a/soak-tests-common/src/main/resources/log4j.properties
+++ b/soak-tests-common/src/main/resources/log4j.properties
@@ -23,6 +23,6 @@ log4j.appender.stdout.layout.ConversionPattern=%d{ABSOLUTE} %5p |%X{test-name}| 
 log4j.logger.com.hazelcast.jet=trace
 log4j.logger.com.hazelcast.internal.cluster=info
 log4j.logger.com.hazelcast=info
-log4j.logger.com.amazonaws=info
+log4j.logger.software.amazon.awssdk=info
 
 log4j.rootLogger=info, stdout


### PR DESCRIPTION
Followup to changes done in CTT-1106,
Migrate Jet Kinesis extension to from deprecated AWS SDK v1 -> v2

Short (60m) run passed: https://jenkins.hazelcast.com/job/jet-soak-tests-patryk/2/ :tada: 
Logs from test: https://jenkins.hazelcast.com/job/jet-soak-tests-patryk/ws/logs/2026_04_13-17_59_16/client-logs/kinesis-test.log
```
7:55:23.630 [[32m INFO[0m] [[34mc.h.j.t.k.KinesisTest[0m] hz.client_1 [jet-isolated] [5.7.0-SNAPSHOT] ClusterStable-KinesisTestPatrykKinesis		Check for insert changes succeeded, latestCheckedCount: 175532
17:55:43.463 [[32m INFO[0m] [[34mc.h.j.t.k.KinesisTest[0m] hz.client_1 [jet-isolated] [5.7.0-SNAPSHOT] ClusterDynamic-KinesisTestPatrykKinesis		Check for insert changes succeeded, latestCheckedCount: 168987
```